### PR TITLE
Remove unwanted text selection when Structure Matching

### DIFF
--- a/src/viewer/log/LogView.tsx
+++ b/src/viewer/log/LogView.tsx
@@ -448,6 +448,13 @@ export default class LogView extends React.Component<Props, State> {
 	}
 
 	render() {
+		const selection = getSelection();
+
+		if(selection !== null){
+			// empty unwanted text selection resulting from Shift-click
+			selection.empty();
+		}
+
 		const { logFile } = this.props;
 		const containerHeight = this.getVisibleRows() * LOG_ROW_HEIGHT;
 		const containerWidth = Object.keys(this.props.collapsibleRows).length > 0 ?

--- a/src/viewer/structures/StructureDialog.tsx
+++ b/src/viewer/structures/StructureDialog.tsx
@@ -479,6 +479,13 @@ export default class StructureDialog extends React.Component<Props, State> {
 			},
 		});
 
+        const selection = getSelection();
+
+		if(selection !== null){
+			// empty unwanted text selection resulting from Shift-click
+			selection.empty();
+		}
+
 		return (
 			<div style={structureDialogBackdropStyle}>
 				<div className="dialog" style={structureDialogDialogStyle}>


### PR DESCRIPTION
Empty the text selection which results from the use of Shift-clicking in the `LogView` and the `StructureDialog`.